### PR TITLE
Create xls_php_vuln.ps1

### DIFF
--- a/Recon/SSRF/xls_php_vuln.ps1
+++ b/Recon/SSRF/xls_php_vuln.ps1
@@ -1,0 +1,44 @@
+$php_files = Get-ChildItem -Path <path_to_php_files> -Recurse -Filter "*.php"
+
+foreach ($php_file in $php_files) {
+  $contents = Get-Content -Path $php_file
+  $vulnerable = $false
+
+  # Check for use of XSLTProcessor class
+  if ($contents -match "new XSLTProcessor") {
+    $vulnerable = $true
+    Write-Output "XSLTProcessor class found in $php_file"
+  }
+
+  # Check for use of loadXML with user-supplied input
+  if ($contents -match "loadXML\(.*$_.*\)") {
+    $vulnerable = $true
+    Write-Output "loadXML with user-supplied input found in $php_file"
+  }
+
+  # Check for use of importStylesheet with user-supplied input
+  if ($contents -match "importStylesheet\(.*$_.*\)") {
+    $vulnerable = $true
+    Write-Output "importStylesheet with user-supplied input found in $php_file"
+  }
+
+  # Check for use of sanitization functions
+  if ($contents -match "htmlspecialchars\(.*$_.*\)") {
+    Write-Output "htmlspecialchars function found in $php_file"
+  }
+  if ($contents -match "strip_tags\(.*$_.*\)") {
+    Write-Output "strip_tags function found in $php_file"
+  }
+
+  # Check for presence of whitelisted XSL functions
+  if ($contents -match "xsl:value-of") {
+    Write-Output "xsl:value-of element found in $php_file"
+  }
+  if ($contents -match "xsl:apply-templates") {
+    Write-Output "xsl:apply-templates element found in $php_file"
+  }
+
+  if ($vulnerable) {
+    Write-Output "Possible XSL vulnerability found in $php_file"
+  }
+}


### PR DESCRIPTION
This script searches through all .php files in a given directory (and its subdirectories) for certain patterns of code that might indicate a vulnerability related to XSL (eXtensible Stylesheet Language).

First, it gets a list of all .php files in the specified directory by using the Get-ChildItem cmdlet, which returns all child items (in this case, files) in a specified location. The -Recurse flag tells it to search through subdirectories as well, and the -Filter flag specifies that it should only return files with the .php extension. These files are stored in the $php_files variable.

Next, the script loops through each file in $php_files using a foreach loop. For each file, it reads the contents into the $contents variable using the Get-Content cmdlet. It then sets a $vulnerable variable to $false, which will be used to track whether any vulnerable code has been found in the file.

The script then checks for several different patterns in the contents of the file. If it finds any of these patterns, it sets the $vulnerable variable to $true and outputs a message indicating which pattern was found and in which file. The script also looks for the presence of certain XSL elements or functions that might be whitelisted (allowed even if a vulnerability is present).

At the end of the loop, if $vulnerable is still $false, the script outputs a message indicating that no vulnerabilities were found in the file. If $vulnerable is $true, it outputs a message indicating that a possible XSL vulnerability was found in the file.